### PR TITLE
Fixed clippy warnings, bumped versions to 0.3.4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@ This is the changelog, summarising changes in each version(some minor changes ma
 
 # 0.3
 
+### 0.3.4
+
+Fixed `Parser::parse_direction`'s `const`-ness by making it a const fn.
+
 ### 0.3.0
 
 Removed `konst::array::try_into_array` macro (it's superceeded by the function of the same name)

--- a/konst/Cargo.toml
+++ b/konst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "konst"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.65.0"
 edition = "2021"
@@ -25,7 +25,7 @@ path = "../konst_proc_macros"
 optional = true
 
 [dependencies.konst_kernel]
-version = "=0.3.0"
+version = "=0.3.4"
 path = "../konst_kernel"
 features = ["rust_1_64", "__for_konst"]
 

--- a/konst/src/cmp/cmp_wrapper.rs
+++ b/konst/src/cmp/cmp_wrapper.rs
@@ -36,7 +36,7 @@ use crate::cmp::{ConstCmp, IsAConstCmp, IsNotStdKind, IsStdKind};
 /// }
 ///
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CmpWrapper<T>(pub T);
 
 impl<'a, T> CmpWrapper<&'a [T]> {

--- a/konst/src/lib.rs
+++ b/konst/src/lib.rs
@@ -306,8 +306,8 @@
 // clippy's opinionated BS
 #![allow(clippy::needless_doctest_main)]
 #![allow(clippy::init_numbered_fields)]
-#![forbid(clippy::missing_const_for_fn)]
 ////////////
+#![forbid(clippy::missing_const_for_fn)]
 #![cfg_attr(
     feature = "nightly_mut_refs",
     feature(const_mut_refs, const_slice_from_raw_parts_mut)

--- a/konst/src/lib.rs
+++ b/konst/src/lib.rs
@@ -306,6 +306,7 @@
 // clippy's opinionated BS
 #![allow(clippy::needless_doctest_main)]
 #![allow(clippy::init_numbered_fields)]
+#![forbid(clippy::missing_const_for_fn)]
 ////////////
 #![cfg_attr(
     feature = "nightly_mut_refs",

--- a/konst/src/lib.rs
+++ b/konst/src/lib.rs
@@ -303,6 +303,10 @@
 //!
 #![deny(missing_docs)]
 #![deny(unused_results)]
+// clippy's opinionated BS
+#![allow(clippy::needless_doctest_main)]
+#![allow(clippy::init_numbered_fields)]
+////////////
 #![cfg_attr(
     feature = "nightly_mut_refs",
     feature(const_mut_refs, const_slice_from_raw_parts_mut)

--- a/konst/src/parsing/non_parsing_methods.rs
+++ b/konst/src/parsing/non_parsing_methods.rs
@@ -111,7 +111,7 @@ impl<'a> Parser<'a> {
     }
 
     /// The direction that the parser was last mutated from.
-    pub fn parse_direction(self) -> ParseDirection {
+    pub const fn parse_direction(self) -> ParseDirection {
         self.parse_direction
     }
 

--- a/konst/src/ptr.rs
+++ b/konst/src/ptr.rs
@@ -95,7 +95,8 @@ pub const unsafe fn as_mut<'a, T: ?Sized>(ptr: *mut T) -> Option<&'a mut T> {
 ///
 ///
 /// ```
-pub const fn is_null<'a, T: ?Sized>(ptr: *const T) -> bool {
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub const fn is_null<T: ?Sized>(ptr: *const T) -> bool {
     unsafe {
         matches!(
             core::mem::transmute::<*const T, Option<NonNull<T>>>(ptr),
@@ -125,6 +126,7 @@ pub mod nonnull {
     ///
     ///
     /// ```
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub const fn new<T: ?Sized>(ptr: *mut T) -> Option<NonNull<T>> {
         unsafe { core::mem::transmute(ptr) }
     }

--- a/konst_kernel/Cargo.toml
+++ b/konst_kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "konst_kernel"
-version = "0.3.0"
+version = "0.3.4"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.57.0"
 edition = "2021"

--- a/konst_kernel/src/chr.rs
+++ b/konst_kernel/src/chr.rs
@@ -5,6 +5,8 @@ mod tests;
 
 pub use char_formatting::*;
 
+// this isn't documented at all, so this lint seems redundant here <_<
+#[allow(clippy::missing_safety_doc)]
 pub const unsafe fn from_u32_unchecked(n: u32) -> char {
     core::mem::transmute(n)
 }

--- a/konst_kernel/src/into_iter/slice_into_iter.rs
+++ b/konst_kernel/src/into_iter/slice_into_iter.rs
@@ -50,6 +50,8 @@ impl<'a, T> ConstIntoIter for &&'a [T] {
 }
 
 impl<'a, T> IntoIterWrapper<&&'a [T], IsStdKind> {
+    // clippy suggests a change that doesn't compile
+    #[allow(clippy::explicit_auto_deref)]
     pub const fn const_into_iter(self) -> Iter<'a, T> {
         Iter {
             slice: *ManuallyDrop::into_inner(self.iter),

--- a/konst_kernel/src/lib.rs
+++ b/konst_kernel/src/lib.rs
@@ -8,6 +8,8 @@
 #![cfg_attr(feature = "nightly_mut_refs", feature(const_mut_refs))]
 #![cfg_attr(feature = "docsrs", feature(doc_cfg))]
 #![deny(unused_results)]
+#![allow(clippy::type_complexity)]
+#![forbid(clippy::missing_const_for_fn)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/konst_kernel/src/slice.rs
+++ b/konst_kernel/src/slice.rs
@@ -8,14 +8,17 @@ pub use self::slice_for_konst::*;
 #[macro_export]
 macro_rules! __slice_from_impl {
     ($slice:ident, $start:ident, $as_ptr:ident, $from_raw_parts:ident, $on_overflow:expr) => {{
-        #[allow(unused_variables)]
+        #[allow(unused_variables, clippy::ptr_offset_with_cast)]
         let (rem, overflowed) = $slice.len().overflowing_sub($start);
 
         if overflowed {
             return $on_overflow;
         }
 
-        unsafe { core::slice::$from_raw_parts($slice.$as_ptr().offset($start as _), rem) }
+        #[allow(clippy::ptr_offset_with_cast)]
+        unsafe {
+            core::slice::$from_raw_parts($slice.$as_ptr().offset($start as _), rem)
+        }
     }};
 }
 

--- a/konst_kernel/src/string/string_for_konst.rs
+++ b/konst_kernel/src/string/string_for_konst.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::len_without_is_empty)]
+
 use crate::chr::{encode_utf8, Utf8Encoded};
 
 #[doc(hidden)]

--- a/konst_kernel/src/type_eq.rs
+++ b/konst_kernel/src/type_eq.rs
@@ -42,7 +42,7 @@ pub trait MakeTypeWitness: TypeWitnessTypeArg {
     const MAKE: Self;
 }
 
-mod type_eq {
+mod type_eq_ {
     use core::marker::PhantomData;
 
     pub struct TypeEq<L: ?Sized, R: ?Sized>(PhantomData<TypeEqHelper<L, R>>);
@@ -87,7 +87,7 @@ mod type_eq {
         }
     }
 }
-pub use type_eq::TypeEq;
+pub use type_eq_::TypeEq;
 
 impl<L: ?Sized, R: ?Sized> Copy for TypeEq<L, R> {}
 


### PR DESCRIPTION
Only bug discovered by clippy is `Parser::parse_direction` not being `const fn` before, now it is `const fn`.