### PR TITLE
mark from_ref function unsafe

### DIFF
--- a/konst/src/ptr.rs
+++ b/konst/src/ptr.rs
@@ -218,7 +218,7 @@ pub mod nonnull {
     ///     assert_eq!(W.as_ref(), "world");
     /// }
     /// ```
-    pub const fn from_ref<T: ?Sized>(reff: &T) -> NonNull<T> {
+    pub const unsafe fn from_ref<T: ?Sized>(reff: &T) -> NonNull<T> {
         unsafe { NonNull::new_unchecked(reff as *const _ as *mut _) }
     }
 
@@ -255,7 +255,7 @@ pub mod nonnull {
     ///
     #[cfg(feature = "mut_refs")]
     #[cfg_attr(feature = "docsrs", doc(cfg(feature = "mut_refs")))]
-    pub const fn from_mut<T: ?Sized>(mutt: &mut T) -> NonNull<T> {
+    pub const unsafe fn from_mut<T: ?Sized>(mutt: &mut T) -> NonNull<T> {
         unsafe { NonNull::new_unchecked(mutt) }
     }
 }

--- a/konst/tests/misc_tests/ptr_tests.rs
+++ b/konst/tests/misc_tests/ptr_tests.rs
@@ -129,8 +129,8 @@ fn nonnull_as_mut_test() {
 
 #[test]
 fn nonnull_from_ref_test() {
-    let str_ptr: NonNull<str> = nonnull::from_ref("hello");
-    let array_ptr: NonNull<[u8; 4]> = nonnull::from_ref(&[3, 5, 8, 13]);
+    let str_ptr: NonNull<str> = unsafe { nonnull::from_ref("hello") };
+    let array_ptr: NonNull<[u8; 4]> = unsafe { nonnull::from_ref(&[3, 5, 8, 13]) };
 
     unsafe {
         assert_eq!(nonnull::as_ref(str_ptr), "hello");
@@ -142,10 +142,10 @@ fn nonnull_from_ref_test() {
 #[cfg(feature = "mut_refs")]
 fn nonnull_from_mut_test() {
     let slice = &mut [3u8, 5, 8, 13][..];
-    let str_ptr: NonNull<[u8]> = nonnull::from_mut(slice);
+    let str_ptr: NonNull<[u8]> = unsafe { nonnull::from_mut(slice) };
 
     let array = &mut [21, 34, 55, 89];
-    let array_ptr: NonNull<[u8; 4]> = nonnull::from_mut(array);
+    let array_ptr: NonNull<[u8; 4]> = unsafe { nonnull::from_mut(array) };
 
     unsafe {
         nonnull::as_mut(str_ptr)[2] += 10;


### PR DESCRIPTION
https://github.com/rodrimati1992/konst/blob/5c0c45febbf03baba073d649397c032d3c88bf9d/konst/src/ptr.rs#L221-L223
https://github.com/rodrimati1992/konst/blob/5c0c45febbf03baba073d649397c032d3c88bf9d/konst/src/ptr.rs#L258-L260
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.