### PR TITLE
0.3.6 release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,8 +18,7 @@ jobs:
       max-parallel: 2
       matrix:
         rust: [
-            # reenable when github updates its stable version
-            # stable,
+            stable,
             beta,
             nightly,
             # the MSRV of konst

--- a/konst/Cargo.toml
+++ b/konst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "konst"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.65.0"
 edition = "2021"
@@ -25,7 +25,7 @@ path = "../konst_proc_macros"
 optional = true
 
 [dependencies.konst_kernel]
-version = "=0.3.5"
+version = "=0.3.6"
 path = "../konst_kernel"
 features = ["rust_1_64", "__for_konst"]
 

--- a/konst/src/polymorphism/type_eq_projection_fn.rs
+++ b/konst/src/polymorphism/type_eq_projection_fn.rs
@@ -158,8 +158,8 @@
 /// // ) -> TypeEq<::foo::Ty<'a, 'b, L, N>, ::foo::Ty<'a, 'b, R, N>>
 /// // where
 /// //     'b: 'a,
-/// //     L: 'a + Debug,
-/// //     R: 'a + Debug,
+/// //     L: 'b + Debug,
+/// //     R: 'b + Debug,
 /// //     [u32; N]: 'a + core::fmt::Debug
 /// type_eq_projection_fn!{
 ///     /// Documentation for the generated function
@@ -171,7 +171,7 @@
 ///         'a,
 ///         'b: 'a,
 ///         // trait bounds in the type parameter list must be parenthesized
-///         T: ('a +  Debug), 
+///         T: ('b +  Debug), 
 ///         const N: usize,
 ///     >
 ///     where

--- a/konst/tests/misc_tests/type_eq_tests.rs
+++ b/konst/tests/misc_tests/type_eq_tests.rs
@@ -10,7 +10,7 @@ fn test_when_all_generic_args_are_passed() {
     struct Ty<'a, 'b: 'a, T: 'a + Debug, const N: usize>(&'a &'b [T; N]);
 
     type_eq_projection_fn! {
-        fn project(T) -> Ty<'a, 'b: 'a, T: 'a + (Debug), const N: usize>
+        fn project(T) -> Ty<'a, 'b: 'a, T: 'b + (Debug), const N: usize>
     }
 
     fn inner<'a, 'b: 'a, T: 'a + Debug, const N: usize>(

--- a/konst_kernel/Cargo.toml
+++ b/konst_kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "konst_kernel"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.57.0"
 edition = "2021"
@@ -18,7 +18,7 @@ include = [
 
 
 [dependencies.typewit]
-version = "1.1"
+version = "1.5"
 
 
 [dev-dependencies.arrayvec]

--- a/konst_kernel/src/lib.rs
+++ b/konst_kernel/src/lib.rs
@@ -64,7 +64,9 @@ pub mod utils;
 
 #[doc(hidden)]
 pub mod __ {
-    pub use crate::type_eq::{HasTypeWitness, MakeTypeWitness, TypeEq, TypeWitnessTypeArg};
+    pub use typewit::{
+        HasTypeWitness, Identity, MakeTypeWitness, TypeEq, TypeFn, TypeWitnessTypeArg,
+    };
 
     #[cfg(feature = "__for_konst")]
     pub use crate::{
@@ -81,6 +83,7 @@ pub mod __ {
 
     pub use core::{
         assert, compile_error, concat,
+        marker::PhantomData,
         mem::{ManuallyDrop, MaybeUninit},
         ops::Range,
         option::Option::{self, None, Some},

--- a/konst_kernel/src/type_eq/make_project_fn.rs
+++ b/konst_kernel/src/type_eq/make_project_fn.rs
@@ -231,7 +231,7 @@ macro_rules! __make_projection_fn {
 
             $($prefix)*
             <$($gen_params)*> (
-                $param: $crate::__::TypeEq<$L, $R>
+                param: $crate::__::TypeEq<$L, $R>
             ) -> $crate::__::TypeEq<
                 $($type_name)* <$($lt_arg,)* $($gen_arg_before,)* $L, $($($gen_arg_after,)*)?>,
                 $($type_name)* <$($lt_arg,)* $($gen_arg_before,)* $R, $($($gen_arg_after,)*)?>,
@@ -241,9 +241,40 @@ macro_rules! __make_projection_fn {
                 $R: $($($rep_ty_bound)*)?,
                 $($($where_preds)*)?
             {
-                unsafe {
-                    $crate::__::TypeEq::new_unchecked()
+                struct __Projector<T>($crate::__::PhantomData<T>);
+
+                impl<$($gen_params)*> $crate::__::TypeFn<$L>
+                for __Projector<
+                    $($type_name)* <
+                        $($lt_arg,)*
+                        $($gen_arg_before,)*
+                        $R,
+                        $($($gen_arg_after,)*)?
+                    >,
+                >
+                where
+                    $L: $($($rep_ty_bound)*)?,
+                    $R: $($($rep_ty_bound)*)?,
+                    $($($where_preds)*)?
+                {
+                    type Output = $($type_name)* <
+                        $($lt_arg,)*
+                        $($gen_arg_before,)*
+                        $L,
+                        $($($gen_arg_after,)*)?
+                    >;
                 }
+
+                param.project::<
+                    __Projector<
+                        $($type_name)* <
+                            $($lt_arg,)*
+                            $($gen_arg_before,)*
+                            $R,
+                            $($($gen_arg_after,)*)?
+                        >
+                    >
+                >()
             }
 
         }

--- a/konst_kernel/src/type_eq/make_project_fn.rs
+++ b/konst_kernel/src/type_eq/make_project_fn.rs
@@ -241,7 +241,7 @@ macro_rules! __make_projection_fn {
                 $R: $($($rep_ty_bound)*)?,
                 $($($where_preds)*)?
             {
-                struct __Projector<T>($crate::__::PhantomData<T>);
+                struct __Projector<T: ?Sized>($crate::__::PhantomData<T>);
 
                 impl<$($gen_params)*> $crate::__::TypeFn<$L>
                 for __Projector<


### PR DESCRIPTION
Removed unsafe from type_eq_projection_fn macro,
this required fixing lifetime bounds in a couple of tests.